### PR TITLE
removed print(dump(sky)) upon connect

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -78,7 +78,6 @@ end
 
 minetest.register_on_joinplayer(function(player)
 	local sky = player:get_attribute("skybox:skybox")
-	print(dump(sky))
 	if not sky or sky == "" then
 		skybox.clear(player)
 	else


### PR DESCRIPTION
No need to add to the log what the active skybox is for the connecting player every time someone connects to the server. Especially on larger servers