### PR TITLE
Fix for skybox.add function not working.

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -90,7 +90,7 @@ skybox.clear = function(player)
 end
 
 skybox.add = function(def)
-	table.add(skies, def)
+	table.insert(skies, def)
 end
 
 skybox.get_skies = function()


### PR DESCRIPTION
When using the skybox.add function, worlds fail to load with the following error:
/skybox/init.lua:90: attempt to call field 'add' (a nil value)

This is referring to the call to table.add in this function.

I see that table.copy is provided by the Minetest lua api but I can't find table.add anywhere.
Perhaps there is a game or mod typically installed along with the skybox mod that provides a table.add function.

Using table.insert instead allows this to work without any added dependencies.